### PR TITLE
Renames variables from reserved C++ keywords to address #8.

### DIFF
--- a/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com.c
+++ b/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com.c
@@ -762,7 +762,7 @@ void cellDvcGetNetworkInfo(int8_t index, xplrCom_cell_netInfo_t *info)
 {
     uDeviceHandle_t dvcHandler = comDevices[index].handler;
 
-    uCellNetGetOperatorStr(dvcHandler, info->operator, 32);
+    uCellNetGetOperatorStr(dvcHandler, info->network_operator, 32);
     memcpy(info->rat,
            ratStr[uCellNetGetActiveRat(dvcHandler)],
            strlen(ratStr[uCellNetGetActiveRat(dvcHandler)])
@@ -776,7 +776,7 @@ void cellDvcGetNetworkInfo(int8_t index, xplrCom_cell_netInfo_t *info)
     uCellNetGetMccMnc(dvcHandler, &info->Mcc, &info->Mnc);
 
     XPLRCOM_CONSOLE(D, "cell network settings:");
-    XPLRCOM_CONSOLE(D, "operator: %s", info->operator);
+    XPLRCOM_CONSOLE(D, "operator: %s", info->network_operator);
     XPLRCOM_CONSOLE(D, "ip: %s", info->ip);
     XPLRCOM_CONSOLE(D, "registered: %d", info->registered);
     XPLRCOM_CONSOLE(D, "RAT: %s", info->rat);

--- a/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com_types.h
+++ b/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com_types.h
@@ -94,7 +94,7 @@ typedef struct xplrCom_cell_config_type {
  * To retrieve it xplrComCellNetworkInfo() needs to called.
 */
 typedef struct xplrCom_cell_netInfo_type {
-    char                network_operator[32];                   /**< Network operator name. */
+    char                network_operator[32];           /**< Network operator name. */
     char                ip[U_CELL_NET_IP_ADDRESS_SIZE]; /**< IP acquired from network carrier. */
     char                apn[64];                        /**< APN of network carrier. */
     char                rat[32];                        /**< RAT used to register. */

--- a/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com_types.h
+++ b/XPLR-HPG-SW/components/hpglib/src/com_service/xplr_com_types.h
@@ -94,7 +94,7 @@ typedef struct xplrCom_cell_config_type {
  * To retrieve it xplrComCellNetworkInfo() needs to called.
 */
 typedef struct xplrCom_cell_netInfo_type {
-    char                operator[32];                   /**< Network operator name. */
+    char                network_operator[32];                   /**< Network operator name. */
     char                ip[U_CELL_NET_IP_ADDRESS_SIZE]; /**< IP acquired from network carrier. */
     char                apn[64];                        /**< APN of network carrier. */
     char                rat[32];                        /**< RAT used to register. */

--- a/XPLR-HPG-SW/components/hpglib/src/nvs_service/xplr_nvs.c
+++ b/XPLR-HPG-SW/components/hpglib/src/nvs_service/xplr_nvs.c
@@ -56,7 +56,7 @@ static xplrNvs_error_t nvsClose(xplrNvs_t *nvs);
  * PUBLIC FUNCTION DEFINITIONS
  * -------------------------------------------------------------- */
 
-xplrNvs_error_t xplrNvsInit(xplrNvs_t *nvs, const char *namespace)
+xplrNvs_error_t xplrNvsInit(xplrNvs_t *nvs, const char *nvs_namespace)
 {
     const esp_partition_t *nvs_partition;
     esp_err_t err;
@@ -107,18 +107,18 @@ xplrNvs_error_t xplrNvsInit(xplrNvs_t *nvs, const char *namespace)
     /* check namespace and create it if not present */
     if (err == ESP_OK) {
         /* check namespace not null */
-        if (namespace != NULL) {
+        if (nvs_namespace != NULL) {
             /* check namespace length */
-            if (strlen(namespace) >= NVS_KEY_NAME_MAX_SIZE - 1) {
+            if (strlen(nvs_namespace) >= NVS_KEY_NAME_MAX_SIZE - 1) {
                 err = ESP_FAIL;
                 XPLRNVS_CONSOLE(E, "namespace <%s> too long (%u), max size is <%u>",
-                                namespace,
-                                strlen(namespace),
+                                nvs_namespace,
+                                strlen(nvs_namespace),
                                 NVS_KEY_NAME_MAX_SIZE);
             } else {
                 /* get namespace to handle */
                 memset(nvs->tag, 0x00, 16);
-                memcpy(nvs->tag, namespace, strlen(namespace));
+                memcpy(nvs->tag, nvs_namespace, strlen(nvs_namespace));
                 XPLRNVS_CONSOLE(D, "namespace set: <%s>", nvs->tag);
                 /* create namespace if not present */
                 err = nvs_open_from_partition(nvsPartitionName, nvs->tag, NVS_READWRITE, &nvs->handler);

--- a/XPLR-HPG-SW/components/hpglib/src/nvs_service/xplr_nvs.h
+++ b/XPLR-HPG-SW/components/hpglib/src/nvs_service/xplr_nvs.h
@@ -69,7 +69,7 @@ typedef struct xplrNvs_type {
  * @param  nvs  driver struct to initialize.
  * @return      XPLR_NVS_OK on success, XPLR_NVS_ERROR otherwise.
  */
-xplrNvs_error_t xplrNvsInit(xplrNvs_t* nvs, const char* namespace);
+xplrNvs_error_t xplrNvsInit(xplrNvs_t* nvs, const char* nvs_namespace);
 
 /**
  * @brief De-initialize nvs driver.


### PR DESCRIPTION
Renames variables named using reserved C++ keywords that were causing compiler errors for C++ projects using `hpglib` to address #8.